### PR TITLE
[example/microphone] show both partial result and result on recognizer state

### DIFF
--- a/vosk/examples/microphone.rs
+++ b/vosk/examples/microphone.rs
@@ -94,8 +94,20 @@ fn recognize<T: Sample + ToSample<i16>>(
         data
     };
 
-    recognizer.accept_waveform(&data);
-    println!("{:#?}", recognizer.partial_result());
+    let state = recognizer.accept_waveform(&data);
+    match state {
+        vosk::DecodingState::Running => {
+            let partial_result = recognizer.partial_result().partial;
+            println!("partial: {}", partial_result);
+        }
+        vosk::DecodingState::Finalized => {
+            let result = recognizer.result();
+            result.single().map(|r| println!("text: {}", r.text));
+        }
+        vosk::DecodingState::Failed => {
+            println!("error")
+        }
+    }
 }
 
 pub fn stereo_to_mono(input_data: &[i16]) -> Vec<i16> {

--- a/vosk/examples/microphone.rs
+++ b/vosk/examples/microphone.rs
@@ -97,12 +97,12 @@ fn recognize<T: Sample + ToSample<i16>>(
     let state = recognizer.accept_waveform(&data);
     match state {
         vosk::DecodingState::Running => {
-            let partial_result = recognizer.partial_result().partial;
-            println!("partial: {}", partial_result);
+            let partial_result = recognizer.partial_result();
+            println!("partial: {:?}", partial_result);
         }
         vosk::DecodingState::Finalized => {
             let result = recognizer.result();
-            result.single().map(|r| println!("text: {}", r.text));
+            result.multiple().map(|r| println!("result: {:?}", r));
         }
         vosk::DecodingState::Failed => {
             println!("error")

--- a/vosk/examples/microphone.rs
+++ b/vosk/examples/microphone.rs
@@ -16,7 +16,7 @@ use cpal::{
     ChannelCount,
 };
 use dasp::{sample::ToSample, Sample};
-use vosk::{Model, Recognizer};
+use vosk::{DecodingState, Model, Recognizer};
 
 fn main() {
     let mut args = env::args();
@@ -96,16 +96,15 @@ fn recognize<T: Sample + ToSample<i16>>(
 
     let state = recognizer.accept_waveform(&data);
     match state {
-        vosk::DecodingState::Running => {
-            let partial_result = recognizer.partial_result();
-            println!("partial: {:#?}", partial_result);
+        DecodingState::Running => {
+            println!("partial: {:#?}", recognizer.partial_result());
         }
-        vosk::DecodingState::Finalized => {
-            let result = recognizer.result();
-            result.multiple().map(|r| println!("result: {:#?}", r));
+        DecodingState::Finalized => {
+            // Result will always be multiple because we called set_max_alternatives
+            println!("result: {:#?}", recognizer.result().multiple().unwrap());
         }
-        vosk::DecodingState::Failed => {
-            println!("error")
+        DecodingState::Failed => {
+            println!("error");
         }
     }
 }

--- a/vosk/examples/microphone.rs
+++ b/vosk/examples/microphone.rs
@@ -98,11 +98,11 @@ fn recognize<T: Sample + ToSample<i16>>(
     match state {
         vosk::DecodingState::Running => {
             let partial_result = recognizer.partial_result();
-            println!("partial: {:?}", partial_result);
+            println!("partial: {:#?}", partial_result);
         }
         vosk::DecodingState::Finalized => {
             let result = recognizer.result();
-            result.multiple().map(|r| println!("result: {:?}", r));
+            result.multiple().map(|r| println!("result: {:#?}", r));
         }
         vosk::DecodingState::Failed => {
             println!("error")


### PR DESCRIPTION
Hi, thank you for the great library!

I've found the microphone example only shows the partial result. I added code that prints both results based on recognizer state.

The output become like this.

![image](https://user-images.githubusercontent.com/10719495/177464256-5c94732f-b473-4188-bbeb-11af298250c8.png)
