### PR TITLE
Documentation in the readme extended

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,10 +59,10 @@ the developer to remember a terminal command or change anything outside the proj
 ##### Troubleshooting
 In real-world scenarios, one will use Rust to cross compile a library (e.g. Android and iOS). Therefore, we need both `cdylib` as well as the `staticlib` as crate-type. If you compile as usual with cargo build (e.g.: `cargo build --target aarch64-apple-ios --release`) it will not work, because cargo tries to build the dylib as well. Fortunately, since rust 1.64. there is a new option for [rustc](https://github.com/rust-lang/cargo/issues/10083) in the stable channel. Because of this, the following will work: `cargo rustc --crate-type staticlib --lib --target aarch64-apple-ios --release` 
 
-### Execution
-Dynamically compiled executable must have access to the vosk library at runtime, static prgrams do not.
+### Usage
+Executables compiled with a dynamic lib must have access to the vosk library at runtime. Executables compiled with a statically compiled library do not.
 
-#### Dynamically compiled executables
+#### Using dynamic libraries
 Do either of the following:
 
 -   **Recommended:** Copy the libraries to the root of the executable
@@ -74,7 +74,7 @@ Do either of the following:
     - Linux: Move them to `/usr/local/lib`, `/usr/lib` or set the `LD_LIBRARY_PATH` environment variable to the directory containing the libraries. Note: `LD_LIBRARY_PATH` is not the same as `LIBRARY_PATH` mentioned in the compilation step.
 
 
-#### Statically compiled executables (iOS-only)
+#### Using static libraries (iOS-only)
 
 - Add the compiled .a library (or libraries if you would like to support more than one architecture) to your iOS project
 - Set `Enable Bitcode` to **no** for your target

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ println!("{:#?}", recognizer.final_result().multiple().unwrap());
 
 ### Compilation (dynamic libraries)
 
-The Vosk-API dynamic libraries have to be discoverable by the rust linker (static libraries are not available, except for [iOS](#compilation-dynamic-libraries)).
+The Vosk-API dynamic libraries have to be discoverable by the rust linker (static libraries are not available, except for [iOS](#compilation-static-libraries)).
 Download the zip file for your platform [here](https://github.com/alphacep/vosk-api/releases) and:
 
 #### Windows and Linux (Recommended)

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ println!("{:#?}", recognizer.final_result().multiple().unwrap());
 
 ### Compilation (dynamic libraries)
 
-The Vosk-API dynamic libraries have to be discoverable by the rust linker (static libraries are not available, except for [iOS](<#compilation (static libraries)>)).
+The Vosk-API dynamic libraries have to be discoverable by the rust linker (static libraries are not available, except for [iOS](#compilation-dynamic-libraries)).
 Download the zip file for your platform [here](https://github.com/alphacep/vosk-api/releases) and:
 
 #### Windows and Linux (Recommended)
@@ -63,39 +63,12 @@ Do either of the following:
 For iOS development you have to use static libraries. Get the static libraries from the [vosk-api][vosk-api-ios] team.
 
 #### macOS-only
-The Rust linker is not able to extract the correct architecture from a static fat file itself. Therefore, for each architecture we need a non-fat file to link with our code.
 
-Example for aarch64:
-```shell
-lipo -info libvosk.a
-# Architectures in the fat file: libvosk.a are: armv7 armv7s arm64 
-lipo libvosk.a -thin arm64 -output arm64/libvosk.a
-lipo -info arm64/libvosk.a
-# Non-fat file: arm64/libvosk.a is architecture: arm64
-```
-A typical use case is to create a lib using Rust to integrate with an iOS App. So the next step is to add `staticlib` as crate-type in the `Cargo.toml` file.
-The static Vosk-API libraries must be discoverable and linked by the Rust linker. One very feasible approach is to create a [build script][build-script-explanation].
+- [Extract](https://llvm.org/docs/CommandGuide/llvm-lipo.html) the correct non-fat file from the static fat file (libvosk.a) for each architecture you would like to support.
+- [Mark your crate type as](https://doc.rust-lang.org/cargo/reference/cargo-targets.html#the-crate-type-field) `staticlib`.
+- Create a [build script][build-script-explanation] and provide cargo with the path to the libraries with `cargo:rustc-link-search=` and `cargo:rustc-link-lib=static=`.
 
-Example build script (build.rs file) for cross compiling aarch64 Android and iOS:
-```rust
-fn add_lib(location: impl AsRef<str>, name: impl AsRef<str>, static_link: bool) {
-    println!("cargo:rustc-link-search={}", location.as_ref());
-    println!(
-        "cargo:rustc-link-lib={}{}",
-        if static_link { "static=" } else { "" },
-        name.as_ref()
-    )
-}
-
-fn main() {
-    let target =  env::var("TARGET").unwrap();
-    match target.as_str() {
-        "aarch64-apple-ios" => add_lib("./ios-libs/ios-device/arm64", "vosk", true),
-        "aarch64-linux-android" => add_lib("./android-libs/arm64-v8a", "vosk", false),
-        _ => {}
-    }
-}
-```
+##### Troubleshooting
 In real-world scenarios, one will use Rust to cross compile a library (e.g. Android and iOS). Therefore, we need both `cdylib` as well as the `staticlib` as crate-type. If you compile as usual with cargo build (e.g.: `cargo build --target aarch64-apple-ios --release`) it will not work, because cargo tries to build the dylib as well. Fortunately, since rust 1.64. there is a new option for [rustc](https://github.com/rust-lang/cargo/issues/10083) in the stable channel. Because of this, the following will work: `cargo rustc --crate-type staticlib --lib --target aarch64-apple-ios --release` 
 
 ### Execution (dynamic libraries)
@@ -121,7 +94,7 @@ If you added your libraries to a directory in your `PATH`, no extra steps are ne
 
 ### Execution (static libraries)
 
-#### macOS-only (target iOS)
+#### iOS-only
 
 - Add the compiled .a library (or libraries if you would like to support more than one architecture) to your iOS project
 - Set `Enable Bitcode` to **no** for your target

--- a/README.md
+++ b/README.md
@@ -32,9 +32,9 @@ println!("{:#?}", recognizer.final_result().multiple().unwrap());
 
 ## Setup
 
-### Compilation
+### Compilation (dynamic libraries)
 
-The Vosk-API dynamic libraries have to be discoverable by the rust linker (static libraries are not available).
+The Vosk-API dynamic libraries have to be discoverable by the rust linker (static libraries are not available, except for [iOS](<#compilation (static libraries)>)).
 Download the zip file for your platform [here](https://github.com/alphacep/vosk-api/releases) and:
 
 #### Windows and Linux (Recommended)
@@ -58,9 +58,49 @@ Do either of the following:
 -   Move them to `/usr/local/lib` or `/usr/lib`.
 -   Set the `LIBRARY_PATH` environment variable to the directory containing the libraries.
 
-### Execution
+### Compilation (static libraries)
+
+For iOS development you have to use static libraries. Get the static libraries from the [vosk-api][vosk-api-ios] team.
+
+#### macOS-only
+The Rust linker is not able to extract the correct architecture from a static fat file itself. Therefore, for each architecture we need a non-fat file to link with our code.
+
+Example for aarch64:
+```shell
+lipo -info libvosk.a
+# Architectures in the fat file: libvosk.a are: armv7 armv7s arm64 
+lipo libvosk.a -thin arm64 -output arm64/libvosk.a
+lipo -info arm64/libvosk.a
+# Non-fat file: arm64/libvosk.a is architecture: arm64
+```
+A typical use case is to create a lib using Rust to integrate with an iOS App. So the next step is to add `staticlib` as crate-type in the `Cargo.toml` file.
+The static Vosk-API libraries must be discoverable and linked by the Rust linker. One very feasible approach is to create a [build script][build-script-explanation].
+
+Example build script (build.rs file) for cross compiling aarch64 Android and iOS:
+```rust
+fn add_lib(location: impl AsRef<str>, name: impl AsRef<str>, static_link: bool) {
+    println!("cargo:rustc-link-search={}", location.as_ref());
+    println!(
+        "cargo:rustc-link-lib={}{}",
+        if static_link { "static=" } else { "" },
+        name.as_ref()
+    )
+}
+
+fn main() {
+    let target =  env::var("TARGET").unwrap();
+    match target.as_str() {
+        "aarch64-apple-ios" => add_lib("./ios-libs/ios-device/arm64", "vosk", true),
+        "aarch64-linux-android" => add_lib("./android-libs/arm64-v8a", "vosk", false),
+        _ => {}
+    }
+}
+```
+In real-world scenarios, one will use Rust to cross compile a library (e.g. Android and iOS). Therefore, we need both `cdylib` as well as the `staticlib` as crate-type. If you compile as usual with cargo build (e.g.: `cargo build --target aarch64-apple-ios --release`) it will not work, because cargo tries to build the dylib as well. Fortunately, since rust 1.64. there is a new option for [rustc](https://github.com/rust-lang/cargo/issues/10083) in the stable channel. Because of this, the following will work: `cargo rustc --crate-type staticlib --lib --target aarch64-apple-ios --release` 
+
+### Execution (dynamic libraries)
 The libraries also have to be discoverable by the executable at runtime.
-You will have to follow one of the approaches in the same section you chose in [compilation](#compilation).
+You will have to follow one of the approaches in the same section you chose in [compilation](<#compilation (dynamic libraries)>).
 
 #### Windows and Linux (Recommended)
 For both approaches, you will need to copy the libraries to the root of the executable
@@ -79,5 +119,15 @@ If you added your libraries to a directory in your `PATH`, no extra steps are ne
     `LD_LIBRARY_PATH` environment variable. Note that this directory does not have to be the same added to
     `LIBRARY_PATH` in the compilation step.
 
+### Execution (static libraries)
+
+#### macOS-only (target iOS)
+
+- Add the compiled .a library (or libraries if you would like to support more than one architecture) to your iOS project
+- Set `Enable Bitcode` to **no** for your target
+- Add the `Accelerate Framework` from the iOS SDK to your project
+- Depending on your library and use case, you have to write some C -> Objective-C -> Swift glue code.
+
 [build-script-explanation]: https://doc.rust-lang.org/cargo/reference/build-scripts.html
 [rust-env-variables]: https://doc.rust-lang.org/cargo/reference/environment-variables.html
+[vosk-api-ios]: https://alphacephei.com/vosk/install#ios-build

--- a/README.md
+++ b/README.md
@@ -32,69 +32,49 @@ println!("{:#?}", recognizer.final_result().multiple().unwrap());
 
 ## Setup
 
-### Compilation (dynamic libraries)
+### Compilation
 
-The Vosk-API dynamic libraries have to be discoverable by the rust linker (static libraries are not available, except for [iOS](#compilation-static-libraries)).
-Download the zip file for your platform [here](https://github.com/alphacep/vosk-api/releases) and:
+The Vosk-API libraries have to be discoverable by the rust linker. Download the zip file containing the dynamic libraries for your platform [here](https://github.com/alphacep/vosk-api/releases). For iOS development you have to use static libraries. Get the static libraries from the [vosk-api][vosk-api-ios] team.
 
-#### Windows and Linux (Recommended)
+#### Dynamic library compilation
 Do either of the following:
 
--   Use the [`RUSTFLAGS` environment variable][rust-env-variables] to provide the path to the variables like so:
+- **Recommended:** Create a [build script][build-script-explanation] and provide cargo with the path to the libraries
+- Use the [`RUSTFLAGS` environment variable][rust-env-variables] to provide the path to the variables like so:
     `RUSTFLAGS=-L/path/to/the/libraries`
--   Create a [build script][build-script-explanation] and provide cargo with the path to the libraries
     with `cargo:rustc-link-search` or `cargo:rustc-link-lib`.
+-   Make the vosk library accessible system or user-wide:
+    - Windows: Move the libraries to a directory in your `PATH` environment variable.
+    - Linux: Move them to `/usr/local/lib`, `/usr/lib` or set the `LIBRARY_PATH` environment variable to the directory containing the libraries.
 
-Although both approaches are equivalent, the latter is more practical as it does not
-require the developer to remember a terminal command.
+Although the approaches are equivalent, using a build script is more convenient because it does not require
+the developer to remember a terminal command or change anything outside the project scope.
 
-#### Windows-only
+#### Static library compilation targeting iOS (macOS-only)
 
--   Move the libraries to a directory in your `PATH` environment variable.
-
-#### Linux-only
-Do either of the following:
-
--   Move them to `/usr/local/lib` or `/usr/lib`.
--   Set the `LIBRARY_PATH` environment variable to the directory containing the libraries.
-
-### Compilation (static libraries)
-
-For iOS development you have to use static libraries. Get the static libraries from the [vosk-api][vosk-api-ios] team.
-
-#### macOS-only
-
-- [Extract](https://llvm.org/docs/CommandGuide/llvm-lipo.html) the correct non-fat file from the static fat file (libvosk.a) for each architecture you would like to support.
+- [Extract](https://llvm.org/docs/CommandGuide/llvm-lipo.html) the correct non-fat file (also called thin file) from the static fat file (libvosk.a) for each architecture you would like to support.
 - [Mark your crate type as](https://doc.rust-lang.org/cargo/reference/cargo-targets.html#the-crate-type-field) `staticlib`.
 - Create a [build script][build-script-explanation] and provide cargo with the path to the libraries with `cargo:rustc-link-search=` and `cargo:rustc-link-lib=static=`.
 
 ##### Troubleshooting
 In real-world scenarios, one will use Rust to cross compile a library (e.g. Android and iOS). Therefore, we need both `cdylib` as well as the `staticlib` as crate-type. If you compile as usual with cargo build (e.g.: `cargo build --target aarch64-apple-ios --release`) it will not work, because cargo tries to build the dylib as well. Fortunately, since rust 1.64. there is a new option for [rustc](https://github.com/rust-lang/cargo/issues/10083) in the stable channel. Because of this, the following will work: `cargo rustc --crate-type staticlib --lib --target aarch64-apple-ios --release` 
 
-### Execution (dynamic libraries)
-The libraries also have to be discoverable by the executable at runtime.
-You will have to follow one of the approaches in the same section you chose in [compilation](<#compilation (dynamic libraries)>).
+### Execution
+Dynamically compiled executable must have access to the vosk library at runtime, static prgrams do not.
 
-#### Windows and Linux (Recommended)
-For both approaches, you will need to copy the libraries to the root of the executable
-(`target/<cargo profile name>` by default). It is recommended that you use a tool such as 
-[cargo-make](https://sagiegurari.github.io/cargo-make/) to automate moving the libraries
-from another, more practical, directory to the destination during build.
+#### Dynamically compiled executables
+Do either of the following:
 
-#### Windows-only
-If you added your libraries to a directory in your `PATH`, no extra steps are needed as long as that is also the case for the target machine.
+-   **Recommended:** Copy the libraries to the root of the executable
+    (`target/<cargo profile name>` by default). It is recommended that you use a tool such as
+    [cargo-make](https://sagiegurari.github.io/cargo-make/) to automate moving the libraries
+    from another, more practical, directory to the destination during build.
+-   Make the vosk library accessible system or user-wide:
+    - Windows: Move the libraries to a directory in your `PATH` environment variable.
+    - Linux: Move them to `/usr/local/lib`, `/usr/lib` or set the `LD_LIBRARY_PATH` environment variable to the directory containing the libraries. Note: `LD_LIBRARY_PATH` is not the same as `LIBRARY_PATH` mentioned in the compilation step.
 
-#### Linux-only
 
--   **If you followed option 1 in the [compilation](#linux-only) section:** No extra steps are needed as long as the
-    target machine also has the libraries in one of the mentioned directories.
--   **If you followed option 2:** You will need to add the directory containing the libraries to the
-    `LD_LIBRARY_PATH` environment variable. Note that this directory does not have to be the same added to
-    `LIBRARY_PATH` in the compilation step.
-
-### Execution (static libraries)
-
-#### iOS-only
+#### Statically compiled executables (iOS-only)
 
 - Add the compiled .a library (or libraries if you would like to support more than one architecture) to your iOS project
 - Set `Enable Bitcode` to **no** for your target


### PR DESCRIPTION
Add compile steps for static libraries (iOS) and execution hints to the README file