### PR TITLE
Added structs and functions necessary for GPU inferencing support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,3 +3,4 @@ members = [
     "vosk",
     "vosk-sys",
 ]
+resolver = "2"

--- a/vosk-sys/src/lib.rs
+++ b/vosk-sys/src/lib.rs
@@ -304,7 +304,7 @@ extern "C" {
     #[doc = " Creates the batch recognizer object"]
     #[doc = ""]
     #[doc = "  @returns model object or NULL if problem occured"]
-    pub fn vosk_batch_model_new() -> *mut VoskBatchModel;
+    pub fn vosk_batch_model_new(model_path: *const ::std::os::raw::c_char) -> *mut VoskBatchModel;
 
     #[doc = " Releases batch model object"]
     pub fn vosk_batch_model_free(model: *mut VoskBatchModel);

--- a/vosk/Cargo.toml
+++ b/vosk/Cargo.toml
@@ -19,3 +19,6 @@ serde = { version = "1.0", features = ["derive"] }
 cpal = "0.14"
 dasp = "0.11"
 hound = "3.5"
+
+[features]
+cuda = []

--- a/vosk/src/lib.rs
+++ b/vosk/src/lib.rs
@@ -15,3 +15,19 @@ mod recognition;
 pub use log::*;
 pub use models::*;
 pub use recognition::*;
+
+/// Init, automatically select a CUDA device and allow multithreading.
+/// Must be called once from the main thread.
+pub fn gpu_init() {
+    unsafe {
+        vosk_sys::vosk_gpu_init()
+    }
+}
+
+/// Init CUDA device in a multi-threaded environment.
+/// Must be called for each thread.
+pub fn gpu_thread_init() {
+    unsafe {
+        vosk_sys::vosk_gpu_thread_init()
+    }
+}

--- a/vosk/src/lib.rs
+++ b/vosk/src/lib.rs
@@ -20,16 +20,12 @@ pub use recognition::*;
 /// Must be called once from the main thread.
 #[cfg(feature = "cuda")]
 pub fn gpu_init() {
-    unsafe {
-        vosk_sys::vosk_gpu_init()
-    }
+    unsafe { vosk_sys::vosk_gpu_init() }
 }
 
 /// Init CUDA device in a multi-threaded environment.
 /// Must be called for each thread.
 #[cfg(feature = "cuda")]
 pub fn gpu_thread_init() {
-    unsafe {
-        vosk_sys::vosk_gpu_thread_init()
-    }
+    unsafe { vosk_sys::vosk_gpu_thread_init() }
 }

--- a/vosk/src/lib.rs
+++ b/vosk/src/lib.rs
@@ -18,6 +18,7 @@ pub use recognition::*;
 
 /// Init, automatically select a CUDA device and allow multithreading.
 /// Must be called once from the main thread.
+#[cfg(feature = "cuda")]
 pub fn gpu_init() {
     unsafe {
         vosk_sys::vosk_gpu_init()
@@ -26,6 +27,7 @@ pub fn gpu_init() {
 
 /// Init CUDA device in a multi-threaded environment.
 /// Must be called for each thread.
+#[cfg(feature = "cuda")]
 pub fn gpu_thread_init() {
     unsafe {
         vosk_sys::vosk_gpu_thread_init()

--- a/vosk/src/models.rs
+++ b/vosk/src/models.rs
@@ -76,3 +76,34 @@ impl Drop for SpeakerModel {
 
 unsafe impl Send for SpeakerModel {}
 unsafe impl Sync for SpeakerModel {}
+
+/// TODO
+pub struct  BatchModel(pub(crate) NonNull<VoskBatchModel>);
+
+impl BatchModel {
+    /// Loads model data from the file and returns the model object, or [`None`]
+    /// if a problem occured.
+    ///
+    /// * `model_path` - the path to the model directory.
+    #[must_use]
+    pub fn new(model_path: impl Into<String>) -> Option<Self> {
+        let model_path_c = CString::new(model_path.into()).ok()?;
+        let model_ptr = unsafe { vosk_batch_model_new(model_path_c.as_ptr()) };
+
+        Some(Self(NonNull::new(model_ptr)?))
+    }
+
+    /// Waits for BatchModel to finish processing input
+    pub fn wait(&self) {
+        unsafe { vosk_batch_model_wait(self.0.as_ptr()) };
+    }
+}
+
+impl Drop for BatchModel {
+    fn drop(&mut self) {
+        unsafe { vosk_batch_model_free(self.0.as_ptr()) }
+    }
+}
+
+unsafe impl Send for BatchModel {}
+unsafe impl Sync for BatchModel {}

--- a/vosk/src/models.rs
+++ b/vosk/src/models.rs
@@ -78,8 +78,10 @@ unsafe impl Send for SpeakerModel {}
 unsafe impl Sync for SpeakerModel {}
 
 /// The same as [`Model`], but uses a CUDA enabled Nvidia GPU and dynamic batching to enable higher throughput.
+#[cfg(feature = "cuda")]
 pub struct  BatchModel(pub(crate) NonNull<VoskBatchModel>);
 
+#[cfg(feature = "cuda")]
 impl BatchModel {
     /// Loads model data from the file and returns the model object, or [`None`]
     /// if a problem occured.
@@ -99,11 +101,14 @@ impl BatchModel {
     }
 }
 
+#[cfg(feature = "cuda")]
 impl Drop for BatchModel {
     fn drop(&mut self) {
         unsafe { vosk_batch_model_free(self.0.as_ptr()) }
     }
 }
 
+#[cfg(feature = "cuda")]
 unsafe impl Send for BatchModel {}
+#[cfg(feature = "cuda")]
 unsafe impl Sync for BatchModel {}

--- a/vosk/src/models.rs
+++ b/vosk/src/models.rs
@@ -93,7 +93,7 @@ impl BatchModel {
         Some(Self(NonNull::new(model_ptr)?))
     }
 
-    /// Waits for BatchModel to finish processing input
+    /// Waits for inferencing to finish
     pub fn wait(&self) {
         unsafe { vosk_batch_model_wait(self.0.as_ptr()) };
     }

--- a/vosk/src/models.rs
+++ b/vosk/src/models.rs
@@ -77,7 +77,7 @@ impl Drop for SpeakerModel {
 unsafe impl Send for SpeakerModel {}
 unsafe impl Sync for SpeakerModel {}
 
-/// TODO
+/// The same as [`Model`], but uses a CUDA enabled Nvidia GPU and dynamic batching to enable higher throughput.
 pub struct  BatchModel(pub(crate) NonNull<VoskBatchModel>);
 
 impl BatchModel {

--- a/vosk/src/models.rs
+++ b/vosk/src/models.rs
@@ -77,38 +77,40 @@ impl Drop for SpeakerModel {
 unsafe impl Send for SpeakerModel {}
 unsafe impl Sync for SpeakerModel {}
 
-/// The same as [`Model`], but uses a CUDA enabled Nvidia GPU and dynamic batching to enable higher throughput.
 #[cfg(feature = "cuda")]
-pub struct BatchModel(pub(crate) NonNull<VoskBatchModel>);
+pub mod batch_model {
+    use std::{ffi::CString, ptr::NonNull};
+    use vosk_sys::*;
+    /// The same as [`Model`], but uses a CUDA enabled Nvidia GPU and dynamic batching to enable higher throughput.
 
-#[cfg(feature = "cuda")]
-impl BatchModel {
-    /// Loads model data from the file and returns the model object, or [`None`]
-    /// if a problem occured.
-    ///
-    /// * `model_path` - the path to the model directory.
-    #[must_use]
-    pub fn new(model_path: impl Into<String>) -> Option<Self> {
-        let model_path_c = CString::new(model_path.into()).ok()?;
-        let model_ptr = unsafe { vosk_batch_model_new(model_path_c.as_ptr()) };
+    pub struct BatchModel(pub(crate) NonNull<VoskBatchModel>);
 
-        Some(Self(NonNull::new(model_ptr)?))
+    impl BatchModel {
+        /// Loads model data from the file and returns the model object, or [`None`]
+        /// if a problem occured.
+        ///
+        /// * `model_path` - the path to the model directory.
+        #[must_use]
+        pub fn new(model_path: impl Into<String>) -> Option<Self> {
+            let model_path_c = CString::new(model_path.into()).ok()?;
+            let model_ptr = unsafe { vosk_batch_model_new(model_path_c.as_ptr()) };
+
+            Some(Self(NonNull::new(model_ptr)?))
+        }
+
+        /// Waits for inferencing to finish
+        pub fn wait(&self) {
+            unsafe { vosk_batch_model_wait(self.0.as_ptr()) };
+        }
     }
 
-    /// Waits for inferencing to finish
-    pub fn wait(&self) {
-        unsafe { vosk_batch_model_wait(self.0.as_ptr()) };
+    impl Drop for BatchModel {
+        fn drop(&mut self) {
+            unsafe { vosk_batch_model_free(self.0.as_ptr()) }
+        }
     }
+
+    unsafe impl Send for BatchModel {}
+
+    unsafe impl Sync for BatchModel {}
 }
-
-#[cfg(feature = "cuda")]
-impl Drop for BatchModel {
-    fn drop(&mut self) {
-        unsafe { vosk_batch_model_free(self.0.as_ptr()) }
-    }
-}
-
-#[cfg(feature = "cuda")]
-unsafe impl Send for BatchModel {}
-#[cfg(feature = "cuda")]
-unsafe impl Sync for BatchModel {}

--- a/vosk/src/models.rs
+++ b/vosk/src/models.rs
@@ -79,7 +79,7 @@ unsafe impl Sync for SpeakerModel {}
 
 /// The same as [`Model`], but uses a CUDA enabled Nvidia GPU and dynamic batching to enable higher throughput.
 #[cfg(feature = "cuda")]
-pub struct  BatchModel(pub(crate) NonNull<VoskBatchModel>);
+pub struct BatchModel(pub(crate) NonNull<VoskBatchModel>);
 
 #[cfg(feature = "cuda")]
 impl BatchModel {

--- a/vosk/src/recognition/mod.rs
+++ b/vosk/src/recognition/mod.rs
@@ -355,8 +355,8 @@ pub mod batch_recognizer {
         }
 
         /// Gets the number of chunks that have yet to be processed
-        pub fn get_pending_chunks(&mut self) -> usize {
-            (unsafe { vosk_batch_recognizer_get_pending_chunks(self.0.as_ptr()) }) as usize
+        pub fn get_pending_chunks(&mut self) -> i32 {
+            (unsafe { vosk_batch_recognizer_get_pending_chunks(self.0.as_ptr()) }) as i32
         }
     }
 

--- a/vosk/src/recognition/mod.rs
+++ b/vosk/src/recognition/mod.rs
@@ -189,7 +189,7 @@ impl Recognizer {
         unsafe { vosk_recognizer_set_partial_words(self.0.as_ptr(), i32::from(enable)) }
     }
 
-    /// TODO
+    /// Enables or disables Natural Language Semantics Markup Language (NLSML) in the output
     pub fn set_nlsml(&mut self, enable: bool) {
         unsafe { vosk_recognizer_set_nlsml(self.0.as_ptr(), i32::from(enable)) }
     }
@@ -283,7 +283,8 @@ impl Drop for Recognizer {
     }
 }
 
-/// TODO
+/// The main object which processes data using GPU inferencing.
+/// Takes audio as input and returns decoded information as words, confidences, times, and other metadata.
 pub struct BatchRecognizer(NonNull<VoskBatchRecognizer>);
 
 impl BatchRecognizer {
@@ -305,7 +306,7 @@ impl BatchRecognizer {
         Some(Self(NonNull::new(recognizer_ptr)?))
     }
 
-    /// TODO
+    /// Enables or disables Natural Language Semantics Markup Language (NLSML) in the output
     pub fn set_nlsml(&mut self, enable: bool) {
         unsafe { vosk_batch_recognizer_set_nlsml(self.0.as_ptr(), i32::from(enable)) }
     }
@@ -320,12 +321,12 @@ impl BatchRecognizer {
         };
     }
 
-    /// TODO
+    /// Closes the stream to the model
     pub fn finish_stream(&mut self) {
         unsafe { vosk_batch_recognizer_finish_stream(self.0.as_ptr()) };
     }
 
-    /// TODO
+    /// Gets the front of the result queue
     pub fn front_result(&mut self) -> Result<Word, serde_json::Error> {
         serde_json::from_str(
             unsafe { CStr::from_ptr(vosk_batch_recognizer_front_result(self.0.as_ptr())) }
@@ -334,12 +335,12 @@ impl BatchRecognizer {
         )
     }
 
-    /// TODO
+    /// Removes the front of the result queue
     pub fn pop(&mut self) {
         unsafe { vosk_batch_recognizer_pop(self.0.as_ptr()) }
     }
 
-    /// TODO
+    /// Gets the number of chunks that have yet to be processed
     pub fn get_pending_chunks(&mut self) -> usize {
         (unsafe { vosk_batch_recognizer_get_pending_chunks(self.0.as_ptr()) }) as usize
     }

--- a/vosk/src/recognition/mod.rs
+++ b/vosk/src/recognition/mod.rs
@@ -1,4 +1,8 @@
-use crate::{BatchModel, Model, SpeakerModel};
+use crate::{Model, SpeakerModel};
+
+#[cfg(feature = "cuda")]
+use crate::BatchModel;
+
 use serde::Deserialize;
 use std::{
     ffi::{CStr, CString},
@@ -285,8 +289,10 @@ impl Drop for Recognizer {
 
 /// The main object which processes data using GPU inferencing.
 /// Takes audio as input and returns decoded information as words, confidences, times, and other metadata.
+#[cfg(feature = "cuda")]
 pub struct BatchRecognizer(NonNull<VoskBatchRecognizer>);
 
+#[cfg(feature = "cuda")]
 impl BatchRecognizer {
 
     /// Creates the recognizer object. Returns [`None`] if a problem occured.
@@ -346,6 +352,7 @@ impl BatchRecognizer {
     }
 }
 
+#[cfg(feature = "cuda")]
 impl Drop for BatchRecognizer {
     fn drop(&mut self) {
         unsafe { vosk_batch_recognizer_free(self.0.as_ptr()) }

--- a/vosk/src/recognition/mod.rs
+++ b/vosk/src/recognition/mod.rs
@@ -1,8 +1,5 @@
 use crate::{Model, SpeakerModel};
 
-#[cfg(feature = "cuda")]
-use crate::BatchModel;
-
 use serde::Deserialize;
 use std::{
     ffi::{CStr, CString},
@@ -287,74 +284,85 @@ impl Drop for Recognizer {
     }
 }
 
-/// The main object which processes data using GPU inferencing.
-/// Takes audio as input and returns decoded information as words, confidences, times, and other metadata.
 #[cfg(feature = "cuda")]
-pub struct BatchRecognizer(NonNull<VoskBatchRecognizer>);
+pub mod batch_recognizer {
+    use crate::batch_model::BatchModel;
+    use vosk_sys::*;
 
-#[cfg(feature = "cuda")]
-impl BatchRecognizer {
+    use std::{ffi::CStr, ptr::NonNull};
 
-    /// Creates the recognizer object. Returns [`None`] if a problem occured.
-    ///
-    /// The recognizers process the speech and return text using shared model data.
-    ///
-    /// * `model` - [`BatchModel`] containing static data for recognizer. Model can be shared
-    /// across recognizers, even running in different threads.
-    ///
-    /// * `sample_rate` - The sample rate of the audio you going to feed into the recognizer.
-    /// Make sure this rate matches the audio content, it is a common issue causing accuracy problems.
-    ///
-    /// [`BatchModel`]: crate::BatchModel
-    #[must_use]
-    pub fn new(model: &BatchModel, sample_rate: f32) -> Option<Self> {
-        let recognizer_ptr = unsafe { vosk_batch_recognizer_new(model.0.as_ptr(), sample_rate) };
-        Some(Self(NonNull::new(recognizer_ptr)?))
+    pub use crate::recognition::results::*;
+
+    /// The main object which processes data using GPU inferencing.
+    /// Takes audio as input and returns decoded information as words, confidences, times, and other metadata.
+
+    pub struct BatchRecognizer(std::ptr::NonNull<VoskBatchRecognizer>);
+
+    impl BatchRecognizer {
+        /// Creates the recognizer object. Returns [`None`] if a problem occured.
+        ///
+        /// The recognizers process the speech and return text using shared model data.
+        ///
+        /// * `model` - [`BatchModel`] containing static data for recognizer. Model can be shared
+        /// across recognizers, even running in different threads.
+        ///
+        /// * `sample_rate` - The sample rate of the audio you going to feed into the recognizer.
+        /// Make sure this rate matches the audio content, it is a common issue causing accuracy problems.
+        ///
+        /// [`BatchModel`]: crate::BatchModel
+        #[must_use]
+        pub fn new(model: &BatchModel, sample_rate: f32) -> Option<Self> {
+            let recognizer_ptr =
+                unsafe { vosk_batch_recognizer_new(model.0.as_ptr(), sample_rate) };
+            Some(Self(NonNull::new(recognizer_ptr)?))
+        }
+
+        /// Enables or disables Natural Language Semantics Markup Language (NLSML) in the output
+        pub fn set_nlsml(&mut self, enable: bool) {
+            unsafe { vosk_batch_recognizer_set_nlsml(self.0.as_ptr(), i32::from(enable)) }
+        }
+
+        /// Accept and process new chunk of voice data.
+        ///
+        /// * `data` - Audio data in PCM 16-bit mono format as an array of i8.
+        pub fn accept_waveform(&mut self, data: &[i8]) {
+            unsafe {
+                vosk_batch_recognizer_accept_waveform(
+                    self.0.as_ptr(),
+                    data.as_ptr(),
+                    data.len() as i32,
+                )
+            };
+        }
+
+        /// Closes the stream to the model
+        pub fn finish_stream(&mut self) {
+            unsafe { vosk_batch_recognizer_finish_stream(self.0.as_ptr()) };
+        }
+
+        /// Gets the front of the result queue
+        pub fn front_result(&mut self) -> Result<Word, serde_json::Error> {
+            serde_json::from_str(
+                unsafe { CStr::from_ptr(vosk_batch_recognizer_front_result(self.0.as_ptr())) }
+                    .to_str()
+                    .unwrap(),
+            )
+        }
+
+        /// Removes the front of the result queue
+        pub fn pop(&mut self) {
+            unsafe { vosk_batch_recognizer_pop(self.0.as_ptr()) }
+        }
+
+        /// Gets the number of chunks that have yet to be processed
+        pub fn get_pending_chunks(&mut self) -> usize {
+            (unsafe { vosk_batch_recognizer_get_pending_chunks(self.0.as_ptr()) }) as usize
+        }
     }
 
-    /// Enables or disables Natural Language Semantics Markup Language (NLSML) in the output
-    pub fn set_nlsml(&mut self, enable: bool) {
-        unsafe { vosk_batch_recognizer_set_nlsml(self.0.as_ptr(), i32::from(enable)) }
-    }
-    
-    /// Accept and process new chunk of voice data.
-    ///
-    /// * `data` - Audio data in PCM 16-bit mono format as an array of i8.
-    pub fn accept_waveform(&mut self, data: &[i8]) {
-        
-        unsafe {
-            vosk_batch_recognizer_accept_waveform(self.0.as_ptr(), data.as_ptr(), data.len() as i32)
-        };
-    }
-
-    /// Closes the stream to the model
-    pub fn finish_stream(&mut self) {
-        unsafe { vosk_batch_recognizer_finish_stream(self.0.as_ptr()) };
-    }
-
-    /// Gets the front of the result queue
-    pub fn front_result(&mut self) -> Result<Word, serde_json::Error> {
-        serde_json::from_str(
-            unsafe { CStr::from_ptr(vosk_batch_recognizer_front_result(self.0.as_ptr())) }
-                .to_str()
-                .unwrap()
-        )
-    }
-
-    /// Removes the front of the result queue
-    pub fn pop(&mut self) {
-        unsafe { vosk_batch_recognizer_pop(self.0.as_ptr()) }
-    }
-
-    /// Gets the number of chunks that have yet to be processed
-    pub fn get_pending_chunks(&mut self) -> usize {
-        (unsafe { vosk_batch_recognizer_get_pending_chunks(self.0.as_ptr()) }) as usize
-    }
-}
-
-#[cfg(feature = "cuda")]
-impl Drop for BatchRecognizer {
-    fn drop(&mut self) {
-        unsafe { vosk_batch_recognizer_free(self.0.as_ptr()) }
+    impl Drop for BatchRecognizer {
+        fn drop(&mut self) {
+            unsafe { vosk_batch_recognizer_free(self.0.as_ptr()) }
+        }
     }
 }


### PR DESCRIPTION
I basically just made some classes in the style of the stuff that was always there, with the exception of `gpu_init()` and `gpu_thread_init()`, which I put in the root of the `vosk` crate.

I know that the recommended dynamic library binaries don't support it, but I need the support for the back end of a project I'm working on.

I think it should be possible to get binaries that do by following the compilation steps of or copying the compiled result out of the GPU containers in [vosk-server](https://github.com/alphacep/vosk-server/), at least for Ubuntu based distros. I'm working on a Windows binary, but I'm not entirely sure I'll be able to do it.