### PR TITLE
Fix LogLevels

### DIFF
--- a/vosk/src/log.rs
+++ b/vosk/src/log.rs
@@ -4,10 +4,7 @@ use vosk_sys::*;
 #[derive(Debug, Default, Clone, Copy)]
 /// Log level for Kaldi messages.
 pub enum LogLevel {
-    /// Print Error, Warn, Info and Debug messages.
-    Debug,
-
-    /// Print Error, Warn, and Info, but not Debug messages (default).
+    /// Print Error, Warn, and Info (default)
     #[default]
     Info,
 
@@ -21,7 +18,6 @@ pub enum LogLevel {
 impl LogLevel {
     pub(self) fn to_c_int(self) -> c_int {
         match self {
-            Self::Debug => 1,
             Self::Info => 0,
             Self::Warn => -1,
             Self::Error => -2,

--- a/vosk/src/log.rs
+++ b/vosk/src/log.rs
@@ -4,12 +4,15 @@ use vosk_sys::*;
 #[derive(Debug, Default, Clone, Copy)]
 /// Log level for Kaldi messages.
 pub enum LogLevel {
-    /// Print Error, Info and Debug messages.
-    ErrorInfoDebug,
+    /// Print Error, Warn, Info and Debug messages.
+    Debug,
 
-    /// Print Error and Info, but not Debug messages (default).
+    /// Print Error, Warn, and Info, but not Debug messages (default).
     #[default]
-    ErrorInfo,
+    Info,
+
+    /// Print Error and Warn messages.
+    Warn,
 
     /// Only print Error messages.
     Error,
@@ -18,16 +21,17 @@ pub enum LogLevel {
 impl LogLevel {
     pub(self) fn to_c_int(self) -> c_int {
         match self {
-            Self::ErrorInfo => 0,
-            Self::Error => -1,
-            Self::ErrorInfoDebug => 1,
+            Self::Debug => 1,
+            Self::Info => 0,
+            Self::Warn => -1,
+            Self::Error => -2,
         }
     }
 }
 
 /// Set log level for Kaldi messages.
 ///
-/// Default: [`LogLevel::ErrorInfo`].
+/// Default: [`LogLevel::Info`].
 pub fn set_log_level(log_level: LogLevel) {
     unsafe { vosk_set_log_level(log_level.to_c_int()) }
 }


### PR DESCRIPTION
Hello! I've been trying to use this library with suppressed logging for all but errors. I.e, in my program I had set:

```rust
vosk::set_log_level(vosk::LogLevel::Error);
```

Despite this setting, I was still getting warning messages, which were causing me some grief. Going to the [Kaldi source](https://github.com/kaldi-asr/kaldi/blob/master/src/base/kaldi-error.h#L74-L78), we can see that there's a misalignment between the `LogLevel` struct and the upstream understanding of log levels (perhaps due to upstream evolution over time). In particular, there's no such thing as a `Debug` level (i.e. sending a value of `1` is not meaningful), but there _is_ `Warn` level (`-1`) before the `Error` level (`-2`). This PR addresses this discrepancy.

Now, **this is a breaking change** as we're redefining the contents of the `LogLevel` enum: adding a new level (`Warn`), removing `Debug` and renaming `ErrorInfo` to be simply `Info`. Due to the mismatch of the enum to the upstream, I don't think there's a reasonable way of making this a non-breaking change.

Not only is this a breaking change, but it's also altering the existing `LogLevel` naming convention. I'm open to changing this, but `ErrorInfoDebug` is an unusual name, differing from both Rust conventions for naming levels as well as the upstream Kaldi's conventions. The new names align with both of these standards.